### PR TITLE
Much more efficient whiteout of disks

### DIFF
--- a/ubuntu-16.04/ubuntu-16.04-minimal.json
+++ b/ubuntu-16.04/ubuntu-16.04-minimal.json
@@ -7,6 +7,8 @@
             "name": "xenial64-minimal-libvirt",
             "type": "qemu",
             "format": "qcow2",
+            "disk_discard": "unmap",
+            "disk_interface": "virtio-scsi",
             "accelerator": "kvm",
             "headless": true,
             "disk_size": "{{user `disk_size`}}",


### PR DESCRIPTION
This becomes essential as you grow the disk. I tried 120GB disk and my
system ground almost to a halt while it zeroed it all out. This method
uses the modern discard feature of SCSI block devices. fstrim will
notify the block device that certain blocks are no longer needed. This
translates into a release of the blocks all the way down to the qcow
image. The resulting .box file is actually a little smaller with this
method (but not much)